### PR TITLE
Create backing image of 20G virtual size

### DIFF
--- a/bin/run.rb
+++ b/bin/run.rb
@@ -97,7 +97,7 @@ else
     warn "Overlyaing existing #{existing_raid}"
     FileUtils.rm_r('raid') if File.exist?('raid')
     FileUtils.mkpath('raid')
-    system("qemu-img create -f qcow2 -o backing_file=#{existing_raid}/1 raid/1 10G") || raise
+    system("qemu-img create -f qcow2 -o backing_file=#{existing_raid}/1 raid/1 20G") || raise
   end
   config[:QEMU_DISABLE_SNAPSHOTS] = true
   config[:MAKETESTSNAPSHOTS] = false


### PR DESCRIPTION
c2766c8683df45d1e5f89bffdd80637949045b2c made size 20G for base image
but didn't update here.. which results in this code path failing.

Fixes: #2