### PR TITLE
Don't install wayland

### DIFF
--- a/neon/tests/plasma/plasma_wayland.pm
+++ b/neon/tests/plasma/plasma_wayland.pm
@@ -42,13 +42,6 @@ sub run {
 
     $self->boot_to_dm; # don't need the x11 session, we'll switch to wayland.
 
-    select_console 'log-console';
-    {
-        assert_script_sudo 'apt update';
-        assert_script_sudo 'apt install -y plasma-wayland-desktop';
-    }
-    select_console 'x11';
-
     assert_and_click 'sddm-choose-session';
     assert_and_click 'sddm-plasma-wayland';
 


### PR DESCRIPTION
Shortly after this hack was introduced, user edition included wayland
session by default, so in test make sure that wayland edition is
included.