### PR TITLE
Fix the qt_compat test

### DIFF
--- a/neon/tests/natives/qt_compat.pm
+++ b/neon/tests/natives/qt_compat.pm
@@ -55,14 +55,20 @@ sub xkill_while_needlematch {
 
 sub run {
     my ($self) = @_;
-    $self->boot;
 
+    # login to sddm
+    $self->boot_to_dm;
+
+    # install packages
     select_console 'log-console';
     assert_script_run 'wget ' . data_url('qt_compat_install.rb'),  16;
     assert_script_sudo 'ruby qt_compat_install.rb '.
                        'kdevelop skrooge kontact plasma-discover',
                        60 * 30;
     select_console 'x11';
+
+    # once install is done, login
+    $self->login;
 
     assert_screen 'folder-desktop', 30;
     # In case we have any lingering windows for whatever weird reason:


### PR DESCRIPTION
qt_compat test waits 30 minutes for whole upgrade, install procedure
which is most likely enough for slow connections.. however this have
another flow.

- We do login to plasma-desktop session
- Switch to tty
- Start script to install/upgrade
- 10(?) minutes later the screen in desktop session gets locked
- After that install/upgrade is done properly we switch to desktop tty
  and wait for folder-desktop but instead are presented by lockscreen

To solve it there are two approches possible,

- Don't login before we install packages
- after installing stuff check if lockscreen needle is matched and
  if so, unlock screen first

I don't like second idea because it is slightly complicated and produces
the different test sequence based on internet speed.